### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,177 +1,226 @@
 Talks
 =============
 
-<a></a>
+<a lang="de"></a>
 
 ## App Strategie - Der Weg zur Nummer Eins
 
 Wie erreiche ich alle Smartphone-Nutzer? Was zeichnet eine gute App aus? Wie erreiche ich ein hohes Engagement der Nutzer? Wie schaffe ich das nötige Wachstum?
 
-* At [Forum Digitales Marketing, Nördlingen](http://tcw-donau-ries.de/wp-content/uploads/2018/01/Forum_Digitales-Marketing.pdf), March 6th, 2018 – [Slides](https://peerigon.github.io/talks/2018-03-06-app-strategie-der-weg-zur-nummer-eins/)
+* Stephan Batteiger
+* [Forum Digitales Marketing, Nördlingen](http://tcw-donau-ries.de/wp-content/uploads/2018/01/Forum_Digitales-Marketing.pdf)
+* March 6th, 2018
+* [Slides](https://peerigon.github.io/talks/2018-03-06-app-strategie-der-weg-zur-nummer-eins/)
 
-<a></a>
+<a lang="en"></a>
 
 ## JavaScript RoadTrip
 
 Smartphone, Tablet, Desktop: Everybody uses Web applications like Spotify, Slack or Facebook every day. So why not develop an infotainment system based on open web technology? We want to share our experience gained in the developing of the Sono Motors infotainment system: What do you have to keep in mind for using it in a car? How can you implement an interface on Smartphone and Dashboard? How is it even possible to control and pilot a car with JavaScript? After this talk your dream of your own infotainment system is closer then ever!
-
-## Unterwegs mit JavaScript
-
-Ob Smartphone, Tablet oder Desktop: Jeder nutzt tagtäglich Webanwendung wie Spotify, Slack oder Facebook. Warum also nicht ein Infotainment System auf Basis offener Webtechnologien entwickeln? Wir wollen unsere Erfahrung während der Entwicklung des Sono Motors Infotainments mit euch teilen: Was gibt es zu beachten bei der Bedienung im Auto? Wie lässt sich ein Interface auf Smartphone & Dashboard realisieren? Wie kann man ein Auto per JavaScript überhaupt ansteuern und somit auch fernsteuern? Nach diesem Talk ist der Traum vom eigenen Infotainment System in greifbarer Nähe!
 
 * Michael Jaser & Jannik Keye
 * [Hackerkiste 2017](https://2017.hackerkiste.de/)
 * September 29th, 2017
 * [Slides](https://peerigon.github.io/talks/2017-09-29-hackerkiste-javascript-roadtrip)
 
-<a></a>
+<a lang="en"></a>
 
 ## HTTP/2 for data networking
 
 Everyone is talking about the impact of HTTP/2 (H2) on static assets like HTML, CSS or images. But what does it mean for data? How does it change REST and do we still need WebSockets? This talk highlights some basics of H2 and aims to answer common questions by API developers with benchmarks performed using H1 and H2 repectively.
-
-## Datenübertragung mit HTTP/2
-
-Jeder spricht über den Einfluss von HTTP/2 (H2) auf statische Dateien wie HTML, CSS oder Bilder. Aber was bedeutet das für die Daten? Wie verändert es REST, und brauchen wir WebSockets überhaupt noch? Dieser Talk beleuchtet einige H2-Grundlagen und beantwortet allgemeine Fragen von API Entwicklern mithilfe von jeweils auf H1 und H2 ausgeführten Benchmarks.
 
 * Michael Jaser
 * [jscraftcamp2017](http://jscraftcamp.org/)
 * July 22nd, 2017
 * [Slides](https://peerigon.github.io/talks/2017-07-22-jscraftcamp-http2-for-data)
 
-<a></a>
+<a lang="en"></a>
 
 ## HTTPS with Let's Encrypt
 
 Since Let's Encrypt launched in 2016, the project has gone through the roof: 20 million issued certificates, almost 25 million fully qualified domains active. Many webhosters are supporting the deployment of Let's Encrypt certificates automatically via their webinterfaces. However, deploying HTTPS professionally brings along higher requirements like [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) in combination with [HPKP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning), which needs more background knowledge and configuration. I will give you a short insight into how Let's Encrypt works and other TLS/HTTPS security best practices.
-
-## HTTPS mit Let’s Encrypt
-
-Seit Let’s Encrypt 2016 auf den Markt gebracht wurde, kennt das Projekt kein Halten mehr: 20 Millionen ausgestellte Zertifikate und fast 25 Millionen aktive Domains. Viele Webhoster unterstützen den Einsatz von „Let’s Encrypt“-Zertifikaten automatisch über ihre Weboberflächen. Jedoch bringt der professionelle Einsatz von HTTPS auch höhere Anforderungen mit sich, wie z.B. [HSTS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security) in Kombination mit [HPKP](https://developer.mozilla.org/en-US/docs/Web/HTTP/Public_Key_Pinning). Diese Optionen benötigen etwas mehr Hintergrundwissen und Konfiguration. Ich werde euch einen kurzen Einblick zur Funktionsweise von Let’s Encrypt geben und andere Sicherheitspraktiken mit HTTPS/TLS vorstellen.
 
 * Carsten Meier
 * [Web&Wine Augsburg](https://www.meetup.com/web-and-wine/events/239843661/)
 * May 16th, 2017
 * [Slides](https://peerigon.github.io/talks/2017-05-16-web-and-wine-https-lets-encrypt)
 
-<a></a>
+<a lang="en"></a>
 
 ## JavaScript on Hardware
 
 There is not need to learn low level languages to interact with hardware anymore. This talk -- which is actually more like a live coding session -- demos hardware interaction on the [espruino Pico](http://www.espruino.com/) and on a [Raspberry Pi](https://www.raspberrypi.org/).
 
-* By Michael Jaser
-* At [Web&Wine Augsburg](https://www.meetup.com/de-DE/web-and-wine/events/237309786/), February 7th, 2017 - [Slides](https://peerigon.github.io/talks/2017-02-07-web-and-wine-js-on-hardware)
+* Michael Jaser
+* [Web&Wine Augsburg](https://www.meetup.com/de-DE/web-and-wine/events/237309786/)
+* February 7th, 2017
+* [Slides](https://peerigon.github.io/talks/2017-02-07-web-and-wine-js-on-hardware)
 
-<a></a>
-
-## CSS from the future
-
-New upcoming CSS features that will blow your mind. Get a sneak preview of CSS custom properties, the CSS grid layout and the mysterious Houdini drafts.
-
-* At [Web&Wine Augsburg](https://www.meetup.com/de-DE/web-and-wine/events/235129165/), November 8th, 2016 – [Slides](https://peerigon.github.io/talks/2016-11-08-css-from-the-future/)
-
-<a></a>
-
-## Introduction to Docker
-
-What is Docker and why we need it - VM vs. Docker - Docker tools - Creating a container - Ecosystem - Alternatives.
-
-* At [Web&Wine Augsburg](https://www.meetup.com/de-DE/web-and-wine/events/234637393/), October 18th, 2016 – [Slides](https://peerigon.github.io/talks/2016-10-18-webandwine-introduction-to-docker/)
-
-<a></a>
-
-## Arbeit ganzheitlich denken
-
-Arbeit ganzheitlich denken: Praxiserfahrungen aus dem Unternehmen Peerigon.
-
-* At [Tag der Regionen, Petersberg](https://www.der-petersberg.de/Tag-der-Regionen-2016), October 3th, 2016 – [Slides](https://peerigon.github.io/talks/2016-10-03-Unternehmenskultur-Peerigon/)
-
-<a></a>
+<a lang="en"></a>
 
 ## The future of frontend tooling
 
 Our frontend toolstack has become quite complex over the past few years. In order to overcome typical problems when building large websites, we've built a variety of tools with shiny names like Grunt, Gulp or Webpack. However, things are about to change. With new technologies like HTTP2, ES2015 and Web Components around the corner, we need to ask ourselves: are the best practices from today still valid in the future? What kind of tools will we be using in the next few years? Will we need them at all? In my talk, I am going to show you how these new technologies will change the way we work.
 
-* At [JSConf Iceland](https://2016.jsconf.is/), August 26th, 2016 – [Slides](https://peerigon.github.io/talks/2016-08-26-jsconf-is-future-frontend-tooling/) / [Video](https://www.youtube.com/watch?v=VYjBp4z4XjY)
-* At [React Vienna](https://www.meetup.com/de-DE/Vienna-ReactJS-Meetup/), January 18th, 2017 – [Slides](https://peerigon.github.io/talks/2017-01-18-react-vienna-future-frontend-tooling)
+* Johannes Ewald
+* [React Vienna](https://www.meetup.com/de-DE/Vienna-ReactJS-Meetup/)
+* January 18th, 2017
+* [Slides](https://peerigon.github.io/talks/2017-01-18-react-vienna-future-frontend-tooling)
 
-<a></a>
+<a lang="en"></a>
+
+## CSS from the future
+
+New upcoming CSS features that will blow your mind. Get a sneak preview of CSS custom properties, the CSS grid layout and the mysterious Houdini drafts.
+
+* Johannes Ewald
+* [Web&Wine Augsburg](https://www.meetup.com/de-DE/web-and-wine/events/235129165/)
+* November 8th, 2016
+* [Slides](https://peerigon.github.io/talks/2016-11-08-css-from-the-future/)
+
+<a lang="en"></a>
+
+## Introduction to Docker
+
+What is Docker and why we need it - VM vs. Docker - Docker tools - Creating a container - Ecosystem - Alternatives.
+
+* Matthias Jahn
+* [Web&Wine Augsburg](https://www.meetup.com/de-DE/web-and-wine/events/234637393/)
+* October 18th, 2016
+* [Slides](https://peerigon.github.io/talks/2016-10-18-webandwine-introduction-to-docker/)
+
+<a lang="de"></a>
+
+## Arbeit ganzheitlich denken
+
+Arbeit ganzheitlich denken: Praxiserfahrungen aus dem Unternehmen Peerigon.
+
+* Stephan Batteiger
+* [Tag der Regionen, Petersberg](https://www.der-petersberg.de/Tag-der-Regionen-2016)
+* October 3th, 2016
+* [Slides](https://peerigon.github.io/talks/2016-10-03-Unternehmenskultur-Peerigon/)
+
+<a lang="en"></a>
+
+## The future of frontend tooling
+
+Our frontend toolstack has become quite complex over the past few years. In order to overcome typical problems when building large websites, we've built a variety of tools with shiny names like Grunt, Gulp or Webpack. However, things are about to change. With new technologies like HTTP2, ES2015 and Web Components around the corner, we need to ask ourselves: are the best practices from today still valid in the future? What kind of tools will we be using in the next few years? Will we need them at all? In my talk, I am going to show you how these new technologies will change the way we work.
+
+* Johannes Ewald
+* [JSConf Iceland](https://2016.jsconf.is/)
+* August 26th, 2016
+* [Slides](https://peerigon.github.io/talks/2016-08-26-jsconf-is-future-frontend-tooling/)
+* [Video](https://www.youtube.com/watch?v=VYjBp4z4XjY)
+
+<a lang="en"></a>
 
 ## Dr. Flexbox or how I learned to stop worrying and vertically align the box
 
 What every frontend developer should know about `display: flex`.
 
-* At [Web&Wine Augsburg](https://www.meetup.com/de-DE/web-and-wine/events/231858488), June 28th, 2016 – [Slides](https://peerigon.github.io/talks/2016-06-28-webandwine-dr-flexbox/)
+* Johannes Ewald
+* [Web&Wine Augsburg](https://www.meetup.com/de-DE/web-and-wine/events/231858488)
+* June 28th, 2016
+* [Slides](https://peerigon.github.io/talks/2016-06-28-webandwine-dr-flexbox/)
 
-<a></a>
+<a lang="de"></a>
 
 ## App Strategie - Der Weg zur Nummer Eins
 
 Wie erreiche ich alle Smartphone-Nutzer? Was zeichnet eine gute App aus? Wie erreiche ich ein hohes Engagement der Nutzer? Wie schaffe ich das nötige Wachstum?
 
-* At [Unternehmensdialog Schwaben, Augsburg](http://www.aitiraum.de/unternehmensdialog-schwaben), Juny 14th, 2016 – [Slides](https://peerigon.github.io/talks/2018-03-06-app-strategie-der-weg-zur-nummer-eins/)
+* Stephan Batteiger
+* [Unternehmensdialog Schwaben, Augsburg](http://www.aitiraum.de/unternehmensdialog-schwaben)
+* Juny 14th, 2016
+* [Slides](https://peerigon.github.io/talks/2018-03-06-app-strategie-der-weg-zur-nummer-eins/)
 
-<a></a>
+<a lang="en"></a>
 
 ## The Future of JavaScript
 
 ES2015 (ES6) landed the browsers near you and you should start using it right now. This talk is about why and how to use ES2015 and what the future of JavaScript will look like.
 
-* At [Web&Speck Innsbruck, Austria](https://www.meetup.com/de-DE/webundspeck/events/227668357), January 28th, 2016 – [Slides](https://peerigon.github.io/talks/2016-01-28-webundspeck-future-of-javascript/)
+* Michael Jaser
+* [Web&Speck Innsbruck, Austria](https://www.meetup.com/de-DE/webundspeck/events/227668357)
+* January 28th, 2016
+* [Slides](https://peerigon.github.io/talks/2016-01-28-webundspeck-future-of-javascript/)
 
-<a></a>
+<a lang="en"></a>
 
 ## Frontend management – yesterday, today and tomorrow?
 
 Detailed overview of the state of frontend management tools and recent updates to underlying technologies like HTTP2 and ES2015 modules.
 
-* At [Web&Wine Augsburg](https://www.meetup.com/de/web-and-wine/events/226911260), December 15th, 2015 – [Slides](https://peerigon.github.io/talks/2015-12-15-webandwine-frontend-management/)
+* Johannes Ewald
+* [Web&Wine Augsburg](https://www.meetup.com/de/web-and-wine/events/226911260)
+* December 15th, 2015
+* [Slides](https://peerigon.github.io/talks/2015-12-15-webandwine-frontend-management/)
 
-<a></a>
+<a lang="en"></a>
 
 ## Native Apps Are Deprecated
 
 State of Mobile Web, Hybrid Apps and what the future will (hopefully) look like.
 
-* At [Xitaso Mobile Day](http://xitaso.com/mobileday), November 7th, 2015 – [Slides](https://peerigon.github.io/talks/2015-11-07-mobile-day/)
+* Michael Jaser
+* [Xitaso Mobile Day](http://xitaso.com/mobileday)
+* November 7th, 2015
+* [Slides](https://peerigon.github.io/talks/2015-11-07-mobile-day/)
 
-<a></a>
+<a lang="en"></a>
 
 ## JSConf.eu 2015 Recap
 
 Recap of JSConf.eu 2015.
 
-* At [Web&Wine Augsburg](https://www.meetup.com/de/web-and-wine/events/225587768/), October 6th, 2015 – [Slides](https://peerigon.github.io/talks/2015-10-06-webandwine-jsconfeu-recap/)
+* Michael Jaser
+* [Web&Wine Augsburg](https://www.meetup.com/de/web-and-wine/events/225587768/)
+* October 6th, 2015
+* [Slides](https://peerigon.github.io/talks/2015-10-06-webandwine-jsconfeu-recap/)
 
-<a></a>
+<a lang="en"></a>
 
 ## Fighting Spaghetti-Code with Promises & Generators
 
 How ES2015 makes your code more readable and maintainable using Promises and Generators.
 
-* At [Web&Wine Augsburg](https://www.meetup.com/de/web-and-wine/events/223784151/), July 21th, 2015 – [Slides](https://peerigon.github.io/talks/2015-07-21-webandwine-fighting-spaghetti-code-with-es2015/fighting-spaghetti-code-with-es2015.pdf)
+* Michael Jaser
+* [Web&Wine Augsburg](https://www.meetup.com/de/web-and-wine/events/223784151/)
+* July 21th, 2015
+* [Slides](https://peerigon.github.io/talks/2015-07-21-webandwine-fighting-spaghetti-code-with-es2015/fighting-spaghetti-code-with-es2015.pdf)
 
-<a></a>
+<a lang="en"></a>
 
 ## [alamid-schema](https://github.com/peerigon/alamid-schema)
 
 Extendable mongoose-like schemas for node.js and the browser.
 
-* At the [munich node.js user group](http://www.mnug.de/archive.html#2014_07_09), July 9th, 2014 – [Slides](https://peerigon.github.io/talks/2014-07-09-MNUG-alamid-schema/) / [Video](https://www.youtube.com/watch?v=U5goZCiuh5U)
+* Michael Jaser
+* [munich node.js user group](http://www.mnug.de/archive.html#2014_07_09)
+* July 9th, 2014
+* [Slides](https://peerigon.github.io/talks/2014-07-09-MNUG-alamid-schema/)
+* [Video](https://www.youtube.com/watch?v=U5goZCiuh5U)
 
-<a></a>
+<a lang="en"></a>
 
 ## [alamid-api](https://github.com/peerigon/alamid-api)
 
 Abstracting different transports (http/websockets) and libraries to a unite them all.
 
-* At the [munich node.js user group](http://www.mnug.de/archive.html#2014_07_09), July 9th, 2014 – [Slides](https://peerigon.github.io/talks/2014-07-09-MNUG-alamid-api/) / [Video](https://www.youtube.com/watch?v=TeNRC0QYBdo)
+* Michael Jaser
+* [munich node.js user group](http://www.mnug.de/archive.html#2014_07_09)
+* July 9th, 2014
+* [Slides](https://peerigon.github.io/talks/2014-07-09-MNUG-alamid-api/)
+* [Video](https://www.youtube.com/watch?v=TeNRC0QYBdo)
 
-<a></a>
+<a lang="en"></a>
 
 ## [webpack](https://webpack.github.io)
 
 Packs CommonJs/AMD modules for the browser. Allows to split your codebase into multiple bundles, which can be loaded on demand. Support loaders to preprocess files, i.e. json, jade, coffee, css, less, ... and your custom stuff.
 
-* At the [munich node.js user group](http://www.mnug.de/archive.html#2014_07_09), July 9th, 2014 – [Slides](https://peerigon.github.io/talks/2014-07-09-MNUG-webpack/) / [Video](https://www.youtube.com/watch?v=EBlUng3IU4E)
+* Johannes Ewald
+* [munich node.js user group](http://www.mnug.de/archive.html#2014_07_09)
+* July 9th, 2014
+* [Slides](https://peerigon.github.io/talks/2014-07-09-MNUG-webpack/)
+* [Video](https://www.youtube.com/watch?v=EBlUng3IU4E)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 Talks
 =============
 
+<a lang="en"></a>
+
+## HTTP/2
+
+HTTP/2 is not the new kid on the block anymore, but it's still not as widely adopted as one might think. This talk is about the history of HTTP, reasons why HTTP 1.x does not work as well anymore and of course about the architecture and features of HTTP/2. 
+
+* Michael Jaser
+* [Hochschule Augsburg, Gastvorlesung Web-Technologien](http://hs-augsburg.de)
+* April 12th, 2018
+* [Slides](https://peerigon.github.io/talks/2018-04-12-hsa-http2/)
+
 <a lang="de"></a>
 
 ## App Strategie - Der Weg zur Nummer Eins


### PR DESCRIPTION
Different iteration of the README.md format in preparation for the talks listing on www.

A couple things I noticed while looking through them: 

1. Marking talks either English or German feels weird, most of the times it only marks the language of the slides, whereas the actual talk might have been given in another language (most obvious is English slides and German presentation)
2. We should accommodate for the *Video* if it is provided
3. Talk titles might be links, e.g. to open source projects

I think given our intended target group for www we don't need to explicitly split the content by language - more recent content is better.

What do you think?